### PR TITLE
ci: update GitHub Actions checkout and setup-python to latest versions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,13 +23,13 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Checkout repository and submodules
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install GENetLib & dependencies


### PR DESCRIPTION
## CI: Update GitHub Actions to latest versions

GitHub Actions `actions/checkout` and `actions/setup-python` have newer versions
with bug fixes, performance improvements, and Node.js compatibility updates:

- `actions/checkout@v3` → `@v4` (Node.js 20, improved performance)
- `actions/setup-python@v3`/`v4` → `@v5` (Node.js 20, improved caching)

**Files updated:**
  - `.github/workflows/CI.yml`: checkout: 2 occurrence(s), setup-python: 1 occurrence(s)

**Why this matters:**
- Node.js 16 (used by older action versions) is EOL since September 2024
- GitHub emits deprecation warnings for v3 and older actions in CI logs
- v4/v5 are functionally equivalent drop-in replacements
